### PR TITLE
Use ovf_format for all input files.

### DIFF
--- a/mumax3c/drivers/driver.py
+++ b/mumax3c/drivers/driver.py
@@ -91,6 +91,7 @@ class Driver(mm.ExternalDriver):
                 self,
                 system,
                 compute=None,  # TODO does mumax3 support compute?
+                ovf_format=ovf_format,
                 **kwargs,
             )
             with open(self._mx3filename(system), "wt", encoding="utf-8") as mx3file:

--- a/mumax3c/scripts/driver.py
+++ b/mumax3c/scripts/driver.py
@@ -5,7 +5,7 @@ import numpy as np
 import mumax3c as mc
 
 
-def driver_script(driver, system, compute=None, **kwargs):
+def driver_script(driver, system, compute=None, ovf_format="bin4", **kwargs):
     mx3 = "tableadd(E_total)\n"
     mx3 += "tableadd(dt)\n"
     mx3 += "tableadd(maxtorque)\n"
@@ -69,7 +69,7 @@ def driver_script(driver, system, compute=None, **kwargs):
                 * (mm.consts.e / (mm.consts.e * mm.consts.hbar / (2.0 * mm.consts.me))),
                 system.m.norm,
             )
-            j.write("j.ovf")
+            j.write("j.ovf", representation=ovf_format)
             mx3 += f"Xi = {zh_li_term.beta}\n"
             mx3 += "Pol = 1\n"  # Current polarization is 1.
             mx3 += 'J.add(LoadFile("j.ovf"), 1)\n'  # 1 means constant in time.

--- a/mumax3c/scripts/energy.py
+++ b/mumax3c/scripts/energy.py
@@ -5,14 +5,16 @@ import ubermagutil.typesystem as ts
 import mumax3c as mc
 
 
-def energy_script(system):
+def energy_script(system, ovf_format):
     mx3 = ""
     for term in system.energy:
         if len(system.energy.get(type=type(term))) > 1:
             raise RuntimeError(
                 "Mumax3 does not allow more than one energy term of the same class."
             )
-        mx3 += globals()[f"{term.__class__.__name__.lower()}_script"](term, system)
+        mx3 += globals()[f"{term.__class__.__name__.lower()}_script"](
+            term, system, ovf_format
+        )
 
     # Demagnetisation in mumax3 is enabled by default.
     if mm.Demag() not in system.energy:
@@ -21,14 +23,16 @@ def energy_script(system):
     return mx3
 
 
-def exchange_script(term, system):
+def exchange_script(term, system, ovf_format):
     mx3 = "// Exchange energy\n"
-    mx3 += mc.scripts.set_parameter(parameter=term.A, name="Aex", system=system)
+    mx3 += mc.scripts.set_parameter(
+        parameter=term.A, name="Aex", system=system, ovf_format=ovf_format
+    )
     mx3 += "tableadd(E_exch)\n"
     return mx3
 
 
-def zeeman_script(term, system):
+def zeeman_script(term, system, ovf_format):
     # mx3 file takes B, not H.
     H = term.H
     if isinstance(H, dict):
@@ -39,32 +43,42 @@ def zeeman_script(term, system):
         B = np.multiply(H, mm.consts.mu0)
 
     mx3 = "// Zeeman\n"
-    mx3 += mc.scripts.set_parameter(parameter=B, name="B_ext", system=system)
+    mx3 += mc.scripts.set_parameter(
+        parameter=B, name="B_ext", system=system, ovf_format=ovf_format
+    )
     mx3 += "tableadd(E_Zeeman)\n"
     return mx3
 
 
-def uniaxialanisotropy_script(term, system):
+def uniaxialanisotropy_script(term, system, ovf_format):
     mx3 = "// UniaxialAnisotropy\n"
     if not isinstance(term.K, ts.descriptors.Parameter):
-        mx3 += mc.scripts.set_parameter(parameter=term.K, name="Ku1", system=system)
+        mx3 += mc.scripts.set_parameter(
+            parameter=term.K, name="Ku1", system=system, ovf_format=ovf_format
+        )
     else:
-        mx3 += mc.scripts.set_parameter(parameter=term.K1, name="Ku1", system=system)
-        mx3 += mc.scripts.set_parameter(parameter=term.K2, name="Ku2", system=system)
+        mx3 += mc.scripts.set_parameter(
+            parameter=term.K1, name="Ku1", system=system, ovf_format=ovf_format
+        )
+        mx3 += mc.scripts.set_parameter(
+            parameter=term.K2, name="Ku2", system=system, ovf_format=ovf_format
+        )
 
-    mx3 += mc.scripts.set_parameter(parameter=term.u, name="anisU", system=system)
+    mx3 += mc.scripts.set_parameter(
+        parameter=term.u, name="anisU", system=system, ovf_format=ovf_format
+    )
     mx3 += "tableadd(E_anis)\n"
     return mx3
 
 
-def demag_script(term, system):
+def demag_script(term, system, ovf_format):
     mx3 = "// Demag\n"
     mx3 += "enabledemag = true\n"
     mx3 += "tableadd(E_demag)\n"
     return mx3
 
 
-def dmi_script(term, system):
+def dmi_script(term, system, ovf_format):
     if not system.energy.get(type=mm.Exchange):
         raise RuntimeError(
             "In mumax3 DMI cannot be used without exchange. "
@@ -86,16 +100,24 @@ def dmi_script(term, system):
         )
 
     mx3 = "// DMI\n"
-    mx3 += mc.scripts.set_parameter(parameter=param_val, name=param_name, system=system)
+    mx3 += mc.scripts.set_parameter(
+        parameter=param_val, name=param_name, system=system, ovf_format=ovf_format
+    )
     # In mumax DMI energy is combined with exchange energy
     return mx3
 
 
-def cubicanisotropy_script(term, system):
+def cubicanisotropy_script(term, system, ovf_format):
     mx3 = "// CubicAnisotropy\n"
-    mx3 += mc.scripts.set_parameter(parameter=term.K, name="Kc1", system=system)
-    mx3 += mc.scripts.set_parameter(parameter=term.u1, name="anisC1", system=system)
-    mx3 += mc.scripts.set_parameter(parameter=term.u2, name="anisC2", system=system)
+    mx3 += mc.scripts.set_parameter(
+        parameter=term.K, name="Kc1", system=system, ovf_format=ovf_format
+    )
+    mx3 += mc.scripts.set_parameter(
+        parameter=term.u1, name="anisC1", system=system, ovf_format=ovf_format
+    )
+    mx3 += mc.scripts.set_parameter(
+        parameter=term.u2, name="anisC2", system=system, ovf_format=ovf_format
+    )
     mx3 += "tableadd(E_anis)\n"
 
     return mx3

--- a/mumax3c/scripts/magnetisation.py
+++ b/mumax3c/scripts/magnetisation.py
@@ -3,12 +3,12 @@ import pathlib
 import mumax3c as mc
 
 
-def magnetisation_script(system, abspath=True):
-    system.m.orientation.write("m0.omf")
+def magnetisation_script(system, ovf_format="bin4", abspath=True):
+    system.m.orientation.write("m0.omf", representation=ovf_format)
     m0_path = pathlib.Path("m0.omf")
     if abspath:
         m0_path = m0_path.absolute().as_posix()  # '/' as path separator required
     mx3 = "// Magnetisation\n"
     mx3 += f'm.LoadFile("{m0_path}")\n'
-    mx3 += mc.scripts.mumax3_regions(system, abspath)
+    mx3 += mc.scripts.mumax3_regions(system, ovf_format, abspath)
     return mx3

--- a/mumax3c/scripts/magnetisation.py
+++ b/mumax3c/scripts/magnetisation.py
@@ -10,5 +10,5 @@ def magnetisation_script(system, ovf_format="bin4", abspath=True):
         m0_path = m0_path.absolute().as_posix()  # '/' as path separator required
     mx3 = "// Magnetisation\n"
     mx3 += f'm.LoadFile("{m0_path}")\n'
-    mx3 += mc.scripts.mumax3_regions(system, ovf_format, abspath)
+    mx3 += mc.scripts.mumax3_regions(system, ovf_format=ovf_format, abspath=abspath)
     return mx3

--- a/mumax3c/scripts/system.py
+++ b/mumax3c/scripts/system.py
@@ -3,6 +3,7 @@ import mumax3c as mc
 
 def system_script(system, ovf_format, abspath=True, **kwargs):
     if ovf_format in ["bin4", "bin8"]:
+        ovf_format = "bin4"  # mumax3 uses single precision
         output_format = "OVF2_BINARY"
     elif ovf_format == "txt":
         output_format = "OVF2_TEXT"
@@ -14,7 +15,9 @@ def system_script(system, ovf_format, abspath=True, **kwargs):
     mx3 += f"OutputFormat = {output_format}\n\n"
     # Mesh and energy scripts.
     mx3 += mc.scripts.mesh_script(system)
-    mx3 += mc.scripts.magnetisation_script(system, abspath)
-    mx3 += mc.scripts.energy_script(system)
+    mx3 += mc.scripts.magnetisation_script(
+        system, ovf_format=ovf_format, abspath=abspath
+    )
+    mx3 += mc.scripts.energy_script(system, ovf_format=ovf_format)
 
     return mx3

--- a/mumax3c/scripts/util.py
+++ b/mumax3c/scripts/util.py
@@ -20,7 +20,7 @@ def _identify_subregions(system):
     return subregion_indices, subregion_dict
 
 
-def mumax3_regions(system, abspath=True):
+def mumax3_regions(system, ovf_format="bin4", abspath=True):
     """Convert ubermag subregions and changing Ms values into mumax3 regions.
 
     In this method, 'region' refers to mumax3, 'subregion refers to ubermag.
@@ -71,7 +71,9 @@ def mumax3_regions(system, abspath=True):
         )
 
     region_path = pathlib.Path("mumax3_regions.omf")
-    df.Field(system.m.mesh, dim=1, value=region_indices).write(str(region_path))
+    df.Field(system.m.mesh, dim=1, value=region_indices).write(
+        str(region_path), representation=ovf_format
+    )
     system.region_relator = region_relator
     if abspath:
         region_path = region_path.absolute().as_posix()  # / as path separator required
@@ -92,7 +94,7 @@ def unique_with_accuracy(array, accuracy=14):
     return np.unique(np.round(array / array_max, decimals=accuracy)) * array_max
 
 
-def set_parameter(parameter, name, system):
+def set_parameter(parameter, name, system, ovf_format="bin4"):
     mx3 = ""
     # Spatially constant scalar parameter.
     if isinstance(parameter, numbers.Real):
@@ -118,7 +120,7 @@ def set_parameter(parameter, name, system):
                         )
 
     elif isinstance(parameter, df.Field) and name == "B_ext":
-        parameter.write("B_ext.ovf")
+        parameter.write("B_ext.ovf", representation=ovf_format)
         mx3 += 'B_ext.add(LoadFile("B_ext.ovf"), 1)\n'  # 1 represents constant in time
 
     else:


### PR DESCRIPTION
The attribute ovf_format is passed to several functions that (currently) don't
need it because mumax3 cannot use fields for many energy terms. However, I
thought passing it everywhere makes the code more consistent and avoids
potential problems should mumax3 ever change.