### PR TITLE
bug fix: current conversion

### DIFF
--- a/mumax3c/scripts/driver.py
+++ b/mumax3c/scripts/driver.py
@@ -64,9 +64,10 @@ def driver_script(driver, system, compute=None, ovf_format="bin4", **kwargs):
                 )
             )
 
+            mu_B = mm.consts.e * mm.consts.hbar / (2.0 * mm.consts.me)
+
             j = -np.multiply(
-                u
-                * (mm.consts.e / (mm.consts.e * mm.consts.hbar / (2.0 * mm.consts.me))),
+                u * 2 * (1 + zh_li_term.beta**2) * mm.consts.e / (mm.consts.g * mu_B),
                 system.m.norm,
             )
             j.to_file("j.ovf", representation=ovf_format)


### PR DESCRIPTION
Bug in the conversion from `u` to `j`.

The equation previously being used was:

$$ \mathbf{u} = \mathbf{J} \frac{Pg\mu_\text{B}}{2eM_s}$$

based on https://www.zurich.ibm.com/st/nanomagnetism/spintevolve.html .
We have now updated this to:

$$ \mathbf{u} = \mathbf{J} \frac{Pg\mu_\text{B}}{2eM_s} \frac{1}{1+\beta^2}$$

based on J. Appl. Phys. 128, 243902 (2020); https://doi.org/10.1063/5.0024382