### PR TITLE
Damping term not required for RelaxDriver

### DIFF
--- a/mumax3c/scripts/driver.py
+++ b/mumax3c/scripts/driver.py
@@ -19,10 +19,9 @@ def driver_script(driver, system, compute=None, ovf_format="bin4", **kwargs):
         mx3 += "tablesave()\n\n"
 
     if isinstance(driver, mc.RelaxDriver):
-        if not system.dynamics.get(type=mm.Damping):
-            raise ValueError("A damping term is needed.")
-        alpha = system.dynamics.get(type=mm.Damping)[0].alpha
-        mx3 += f"alpha = {alpha}\n"
+        if system.dynamics.get(type=mm.Damping):
+            alpha = system.dynamics.get(type=mm.Damping)[0].alpha
+            mx3 += f"alpha = {alpha}\n"
 
         for attr, value in driver:
             if attr != "evolver":


### PR DESCRIPTION
Mumax documentation is not clear about setting alpha, it is not needed or harmful :

"Relax() tries to evolve the magnetization as closely as possible to the minimum energy state. This function assumes all excitations have been turned off (temperature, electrical current, time-dependent magnetic fields). During relax precession is disabled and the time t does not increase. There is no need to set high damping."